### PR TITLE
FOLIO-3631: platform-minimal Dockerfile apk upgrade fixing curl

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -9,7 +9,11 @@ WORKDIR /etc/folio/stripes
 
 COPY . /etc/folio/stripes/
 
-RUN apk add --no-cache alpine-sdk python3
+RUN apk upgrade \
+ && apk add \
+      alpine-sdk \
+      python3 \
+ && rm -rf /var/cache/apk/*
 RUN yarn config set python /usr/bin/python3
 
 RUN yarn config set @folio:registry https://repository.folio.org/repository/npm-folioci/
@@ -19,6 +23,10 @@ RUN yarn build output --okapi $OKAPI_URL --tenant $TENANT_ID
 
 # nginx stage
 FROM nginx:stable-alpine
+
+# Install latest patch versions of packages: https://pythonspeed.com/articles/security-updates-in-docker/
+RUN apk upgrade --no-cache
+
 EXPOSE 80
 
 COPY --from=stripes_build /etc/folio/stripes/output /usr/share/nginx/html


### PR DESCRIPTION
Use apk upgrade to install latest patch versions of packages:
https://pythonspeed.com/articles/security-updates-in-docker/

This will upgrade curl fixing Double Free and Cleartext Transmission of Sensitive Information:
https://www.cve.org/CVERecord?id=CVE-2022-42915
https://www.cve.org/CVERecord?id=CVE-2022-42916
https://security.snyk.io/vuln/SNYK-ALPINE316-CURL-3063711