### PR TITLE
FOLIO-3632: platform-minimal Dockerfile node:16-alpine

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:lts-alpine3.14 as stripes_build
+FROM node:16-alpine as stripes_build
 
 ARG OKAPI_URL=http://localhost:9130
 ARG TENANT_ID=diku


### PR DESCRIPTION
Replace
`FROM node:lts-alpine3.14 as stripes_build`
by
`FROM node:16-alpine as stripes_build`

The alpine3.14 based Node containers have been no longer maintained since 2022-06-07. The have been replaced by alpine3.16: https://github.com/nodejs/docker-node/pull/1729/files

Node 16 is no longer the current LTS version. Node 18 has been the current LTS version since 2022-10-25.

Therefore we must request Node 16. Otherwise the build fails with
```
error postcss-nesting@8.0.1: The engine "node" is incompatible with this module. Expected version "12 - 16". Got "18.12.0"
```