### PR TITLE
STRWEB-61 lock enhanced-resolve to 5.10.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "@folio/stripes-cli": "^2.4.0",
     "@rehooks/local-storage": "2.4.0",
     "colors": "1.4.0",
+    "enhanced-resolve": "~5.10.0",
     "final-form": "^4.20.4",
     "minimist": "^1.2.3",
     "moment": "~2.29.0",


### PR DESCRIPTION
Applying same potential remedy as for folio-org/platform-complete#2215

Avoid the buggy 5.11.0 release that appears to be incompatible with webpack-virtual-modules. Additional details at
folio-org/stripes-webpack#81.

Refs [STRWEB-61](https://issues.folio.org/browse/STRWEB-61)