### PR TITLE
STRWEB-62: Remove enhanced-resolve resolutions entry

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     "@folio/stripes-cli": "^2.4.0",
     "@rehooks/local-storage": "2.4.0",
     "colors": "1.4.0",
-    "enhanced-resolve": "~5.10.0",
     "final-form": "^4.20.4",
     "minimist": "^1.2.3",
     "moment": "~2.29.0",


### PR DESCRIPTION
https://issues.folio.org/browse/STRWEB-62

This PR removes `enhanced-resolve` resolutions entry since this was fixed directly in webpack: https://github.com/webpack/enhanced-resolve/pull/364